### PR TITLE
feat: add npm package update agent workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 20
+  # Security-only updates via Dependabot.
+  # Routine version bumps are handled by the npm-update-agent workflow
+  # (.github/workflows/npm-update-agent.yml) which also checks for breaking changes.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Only open PRs for security vulnerabilities
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/.github/scripts/analyze-updates.js
+++ b/.github/scripts/analyze-updates.js
@@ -1,0 +1,229 @@
+/**
+ * analyze-updates.js
+ *
+ * Scans for outdated npm packages and categorises each update as:
+ *   - safe     : patch / minor bump, or major bump with no breaking-change keywords found
+ *   - breaking : major bump where release notes contain breaking-change indicators
+ *   - uncertain: major bump where changelog could not be fetched (treated as needing review)
+ *
+ * Outputs:
+ *   safe-updates.json     – array of safe update objects
+ *   breaking-updates.json – array of breaking / uncertain update objects
+ *   GITHUB_OUTPUT flags   – has_safe_updates, has_breaking_updates
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+// ── Semver helpers ──────────────────────────────────────────────────────────
+
+function parseSemver(version) {
+  const clean = String(version).replace(/^[^0-9]*/, '');
+  const m = clean.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+function cmpVersions(a, b) {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+// ── npm registry ────────────────────────────────────────────────────────────
+
+async function fetchPackageInfo(name) {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`, {
+      headers: { Accept: 'application/json' },
+    });
+    return res.ok ? res.json() : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── GitHub releases ─────────────────────────────────────────────────────────
+
+async function fetchReleasesSince(owner, repo, fromVersion, token) {
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=50`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!res.ok) return null;
+
+    const releases = await res.json();
+    const from = parseSemver(fromVersion);
+    return releases.filter((r) => {
+      const v = parseSemver(r.tag_name);
+      return v && from && cmpVersions(v, from) > 0;
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ── Breaking-change detection ───────────────────────────────────────────────
+
+const BREAKING_PATTERNS = [
+  /BREAKING[\s_-]CHANGE/gi,
+  /breaking change/gi,
+  /incompatible/gi,
+  /removed?\s+support/gi,
+  /dropped?\s+support/gi,
+  /no longer\s+support/gi,
+  /deprecated\s+and\s+removed/gi,
+  /migration\s+guide/gi,
+  /upgrade\s+guide/gi,
+  /API\s+change/gi,
+];
+
+function detectBreaking(text) {
+  if (!text) return false;
+  return BREAKING_PATTERNS.some((p) => p.test(text));
+}
+
+// ── Per-package analysis ────────────────────────────────────────────────────
+
+async function analyzePackage(name, current, latest, token) {
+  const curVer = parseSemver(current);
+  const latVer = parseSemver(latest);
+
+  if (!curVer || !latVer) {
+    return { updateType: 'unknown', hasBreaking: null, reason: 'Could not parse version numbers' };
+  }
+
+  const isMajor = latVer.major > curVer.major;
+  const isMinor = latVer.major === curVer.major && latVer.minor > curVer.minor;
+  const updateType = isMajor ? 'major' : isMinor ? 'minor' : 'patch';
+
+  if (!isMajor) {
+    return { updateType, hasBreaking: false, reason: `${updateType} version bump – generally safe` };
+  }
+
+  // ── Major bump: inspect GitHub release notes ──────────────────────────────
+  const pkgInfo = await fetchPackageInfo(name);
+  if (!pkgInfo) {
+    return {
+      updateType,
+      hasBreaking: null,
+      reason: 'Could not reach npm registry',
+    };
+  }
+
+  const repoUrl = pkgInfo.repository?.url || pkgInfo.homepage || '';
+  const ghMatch = repoUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+
+  if (!ghMatch) {
+    return {
+      updateType,
+      hasBreaking: null,
+      reason: 'No GitHub repository found – changelog unavailable',
+      npmUrl: `https://www.npmjs.com/package/${name}?activeTab=versions`,
+    };
+  }
+
+  const [, owner, repo] = ghMatch;
+  const releases = await fetchReleasesSince(owner, repo, current, token);
+
+  if (!releases) {
+    return {
+      updateType,
+      hasBreaking: null,
+      reason: 'Could not fetch GitHub releases',
+      githubUrl: `https://github.com/${owner}/${repo}/releases`,
+    };
+  }
+
+  const allNotes = releases.map((r) => r.body || '').join('\n');
+  const hasBreaking = detectBreaking(allNotes);
+
+  return {
+    updateType,
+    hasBreaking,
+    reason: hasBreaking
+      ? 'Breaking-change keywords found in release notes'
+      : 'No breaking-change keywords found in release notes',
+    githubUrl: `https://github.com/${owner}/${repo}/releases`,
+    releaseCount: releases.length,
+    affectedReleases: releases.slice(0, 5).map((r) => ({ tag: r.tag_name, title: r.name })),
+  };
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN || '';
+
+  // npm outdated exits with code 1 when packages are outdated – use spawnSync
+  const result = spawnSync('npm', ['outdated', '--json'], { encoding: 'utf8' });
+  let outdated = {};
+  try {
+    outdated = JSON.parse(result.stdout || '{}');
+  } catch {
+    outdated = {};
+  }
+
+  const packages = Object.entries(outdated);
+
+  if (packages.length === 0) {
+    console.log('✅ All packages are up to date.');
+    fs.writeFileSync('safe-updates.json', '[]');
+    fs.writeFileSync('breaking-updates.json', '[]');
+    writeOutputFlag('has_safe_updates', 'false');
+    writeOutputFlag('has_breaking_updates', 'false');
+    return;
+  }
+
+  console.log(`🔍 Found ${packages.length} outdated package(s): ${packages.map(([n]) => n).join(', ')}\n`);
+
+  const safeUpdates = [];
+  const breakingUpdates = [];
+
+  for (const [name, info] of packages) {
+    const current = info.current;
+    const latest = info.latest;
+    process.stdout.write(`  Analyzing ${name}: ${current} → ${latest} … `);
+
+    const analysis = await analyzePackage(name, current, latest, token);
+
+    const entry = { package: name, current, wanted: info.wanted, latest, ...analysis };
+    const verdict =
+      analysis.hasBreaking === false ? '✅ safe' : analysis.hasBreaking ? '🔴 breaking' : '⚠️  uncertain';
+    console.log(`${verdict} (${analysis.reason})`);
+
+    if (analysis.hasBreaking === false) {
+      safeUpdates.push(entry);
+    } else {
+      // breaking === true OR null (uncertain) both require human/agent review
+      breakingUpdates.push({ ...entry, uncertain: analysis.hasBreaking === null });
+    }
+  }
+
+  fs.writeFileSync('safe-updates.json', JSON.stringify(safeUpdates, null, 2));
+  fs.writeFileSync('breaking-updates.json', JSON.stringify(breakingUpdates, null, 2));
+
+  console.log(`\n📦 Safe updates:        ${safeUpdates.length}`);
+  console.log(`⚠️  Needs review:        ${breakingUpdates.length}`);
+
+  writeOutputFlag('has_safe_updates', String(safeUpdates.length > 0));
+  writeOutputFlag('has_breaking_updates', String(breakingUpdates.length > 0));
+}
+
+function writeOutputFlag(key, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/scripts/analyze-updates.js
+++ b/.github/scripts/analyze-updates.js
@@ -7,9 +7,9 @@
  *   - uncertain: major bump where changelog could not be fetched (treated as needing review)
  *
  * Outputs:
- *   safe-updates.json     – array of safe update objects
- *   breaking-updates.json – array of breaking / uncertain update objects
- *   GITHUB_OUTPUT flags   – has_safe_updates, has_breaking_updates
+ *   safe-updates.json     - array of safe update objects
+ *   breaking-updates.json - array of breaking / uncertain update objects
+ *   GITHUB_OUTPUT flags   - has_safe_updates, has_breaking_updates
  */
 
 'use strict';
@@ -105,7 +105,7 @@ async function analyzePackage(name, current, latest, token) {
   const updateType = isMajor ? 'major' : isMinor ? 'minor' : 'patch';
 
   if (!isMajor) {
-    return { updateType, hasBreaking: false, reason: `${updateType} version bump – generally safe` };
+    return { updateType, hasBreaking: false, reason: `${updateType} version bump - generally safe` };
   }
 
   // ── Major bump: inspect GitHub release notes ──────────────────────────────
@@ -125,7 +125,7 @@ async function analyzePackage(name, current, latest, token) {
     return {
       updateType,
       hasBreaking: null,
-      reason: 'No GitHub repository found – changelog unavailable',
+      reason: 'No GitHub repository found - changelog unavailable',
       npmUrl: `https://www.npmjs.com/package/${name}?activeTab=versions`,
     };
   }
@@ -162,7 +162,7 @@ async function analyzePackage(name, current, latest, token) {
 async function main() {
   const token = process.env.GITHUB_TOKEN || '';
 
-  // npm outdated exits with code 1 when packages are outdated – use spawnSync
+  // npm outdated exits with code 1 when packages are outdated - use spawnSync
   const result = spawnSync('npm', ['outdated', '--json'], { encoding: 'utf8' });
   let outdated = {};
   try {

--- a/.github/scripts/apply-updates.js
+++ b/.github/scripts/apply-updates.js
@@ -28,7 +28,7 @@ for (const update of safeUpdates) {
   const section = pkg.dependencies?.[name] != null ? 'dependencies' : 'devDependencies';
 
   if (!pkg[section]?.[name]) {
-    console.warn(`⚠️  ${name} not found in package.json – skipping`);
+    console.warn(`⚠️  ${name} not found in package.json - skipping`);
     continue;
   }
 
@@ -69,7 +69,7 @@ body += `**${applied.length}** package(s) updated.\n\n`;
 
 if (majorList.length > 0) {
   body += `## 🔴 Major Updates\n`;
-  body += `> Changelog was reviewed – no breaking changes detected.\n\n`;
+  body += `> Changelog was reviewed - no breaking changes detected.\n\n`;
   body += `| Package | From | To | Notes |\n|---|---|---|---|\n`;
   body += majorList.map((u) => tableRow(u, true)).join('\n') + '\n\n';
 }
@@ -86,7 +86,7 @@ if (patchList.length > 0) {
   body += patchList.map((u) => tableRow(u)).join('\n') + '\n\n';
 }
 
-body += `---\n*Created automatically – please review and merge if the site looks good.*\n`;
+body += `---\n*Created automatically - please review and merge if the site looks good.*\n`;
 
 fs.writeFileSync('pr-body.md', body);
 console.log('\n📝 PR body written to pr-body.md');

--- a/.github/scripts/apply-updates.js
+++ b/.github/scripts/apply-updates.js
@@ -1,0 +1,92 @@
+/**
+ * apply-updates.js
+ *
+ * Reads safe-updates.json, patches package.json version ranges,
+ * runs `npm install` to regenerate package-lock.json,
+ * and writes pr-body.md for the pull request.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const safeUpdates = JSON.parse(fs.readFileSync('safe-updates.json', 'utf8'));
+
+if (safeUpdates.length === 0) {
+  console.log('No safe updates to apply.');
+  process.exit(0);
+}
+
+// ── Patch package.json ───────────────────────────────────────────────────────
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const applied = [];
+
+for (const update of safeUpdates) {
+  const { package: name, latest, current, updateType } = update;
+  const section = pkg.dependencies?.[name] != null ? 'dependencies' : 'devDependencies';
+
+  if (!pkg[section]?.[name]) {
+    console.warn(`⚠️  ${name} not found in package.json – skipping`);
+    continue;
+  }
+
+  // Preserve the version prefix (^, ~, empty, etc.)
+  const prefix = pkg[section][name].match(/^[^0-9]*/)?.[0] ?? '^';
+  pkg[section][name] = `${prefix}${latest}`;
+  applied.push({ name, current, latest, updateType, section });
+  console.log(`  ✅ ${name}: ${current} → ${latest}`);
+}
+
+if (applied.length === 0) {
+  console.log('Nothing to update after scanning package.json.');
+  process.exit(0);
+}
+
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+console.log('\nUpdated package.json. Running npm install…');
+execSync('npm install', { stdio: 'inherit' });
+
+// ── Generate PR body ─────────────────────────────────────────────────────────
+
+const date = new Date().toISOString().split('T')[0];
+const patchList = applied.filter((u) => u.updateType === 'patch');
+const minorList = applied.filter((u) => u.updateType === 'minor');
+const majorList = applied.filter((u) => u.updateType === 'major');
+
+function tableRow(u, withNotes = false) {
+  const info = safeUpdates.find((s) => s.package === u.name);
+  const notes = info?.githubUrl ? `[📋 Release notes](${info.githubUrl})` : '—';
+  return withNotes
+    ? `| \`${u.name}\` | \`${u.current}\` | \`${u.latest}\` | ${notes} |`
+    : `| \`${u.name}\` | \`${u.current}\` | \`${u.latest}\` |`;
+}
+
+let body = `# 📦 npm Package Updates\n\n`;
+body += `> Auto-generated on **${date}** by the [npm update agent](.github/workflows/npm-update-agent.yml). Build verification passed ✅\n\n`;
+body += `**${applied.length}** package(s) updated.\n\n`;
+
+if (majorList.length > 0) {
+  body += `## 🔴 Major Updates\n`;
+  body += `> Changelog was reviewed – no breaking changes detected.\n\n`;
+  body += `| Package | From | To | Notes |\n|---|---|---|---|\n`;
+  body += majorList.map((u) => tableRow(u, true)).join('\n') + '\n\n';
+}
+
+if (minorList.length > 0) {
+  body += `## 🟡 Minor Updates\n\n`;
+  body += `| Package | From | To |\n|---|---|---|\n`;
+  body += minorList.map((u) => tableRow(u)).join('\n') + '\n\n';
+}
+
+if (patchList.length > 0) {
+  body += `## 🟢 Patch Updates\n\n`;
+  body += `| Package | From | To |\n|---|---|---|\n`;
+  body += patchList.map((u) => tableRow(u)).join('\n') + '\n\n';
+}
+
+body += `---\n*Created automatically – please review and merge if the site looks good.*\n`;
+
+fs.writeFileSync('pr-body.md', body);
+console.log('\n📝 PR body written to pr-body.md');

--- a/.github/scripts/create-breaking-issue.js
+++ b/.github/scripts/create-breaking-issue.js
@@ -1,10 +1,12 @@
 /**
  * create-breaking-issue.js
  *
- * Reads breaking-updates.json and opens a GitHub issue that lists every
- * package with a detected (or uncertain) breaking change.
- * The issue is labelled `dependencies` + `needs-review` so it can be
- * picked up by a team member or a GitHub Copilot coding agent.
+ * Reads breaking-updates.json and creates one GitHub issue **per package**
+ * that has a detected (or uncertain) breaking change.
+ *
+ * Each issue is labelled with `copilot` so that GitHub Copilot coding agent
+ * automatically picks it up, attempts the upgrade, fixes build errors,
+ * and opens a PR.
  */
 
 'use strict';
@@ -26,81 +28,10 @@ if (!token || !repoFullName) {
   process.exit(1);
 }
 
+const [owner, repo] = repoFullName.split('/');
 const date = new Date().toISOString().split('T')[0];
 
-// ── Build issue body ─────────────────────────────────────────────────────────
-
-let body = `# ⚠️ npm Packages Requiring Manual Review\n\n`;
-body += `The **npm update agent** detected the following packages that either contain breaking changes or could not be verified automatically. Please review before updating.\n\n`;
-body += `**Detected on:** ${date}\n\n`;
-body += `---\n\n`;
-
-for (const u of breakingUpdates) {
-  const badge = u.uncertain ? '⚠️ Uncertain' : '🔴 Breaking changes detected';
-  body += `## \`${u.package}\` — \`${u.current}\` → \`${u.latest}\` (${u.updateType})\n\n`;
-  body += `| Field | Value |\n|---|---|\n`;
-  body += `| Status | ${badge} |\n`;
-  body += `| Reason | ${u.reason} |\n`;
-
-  if (u.githubUrl) body += `| Release notes | [View on GitHub](${u.githubUrl}) |\n`;
-  if (u.npmUrl) body += `| npm page | [View on npm](${u.npmUrl}) |\n`;
-
-  if (u.affectedReleases?.length) {
-    const tags = u.affectedReleases.map((r) => `\`${r.tag}\``).join(', ');
-    body += `| Versions to review | ${tags} |\n`;
-  }
-
-  body += `\n`;
-}
-
-body += `---\n\n`;
-body += `## ✅ Suggested Action Steps\n\n`;
-body += `1. Open the release-notes links above and check for removed APIs or config changes.\n`;
-body += `2. If the update is safe, run locally:\n`;
-body += `   \`\`\`bash\n   npm install <package>@latest\n   npm run build   # or: hexo generate\n   \`\`\`\n`;
-body += `3. Fix any broken code (imports, config keys, deprecated options).\n`;
-body += `4. Push a PR and let the CI build verify the result.\n\n`;
-body += `---\n`;
-body += `> 🤖 This issue was automatically created by the [npm update agent workflow](.github/workflows/npm-update-agent.yml).\n`;
-
-// ── Create the GitHub issue ──────────────────────────────────────────────────
-
-const title = `⚠️ [npm Update Agent] ${breakingUpdates.length} package(s) need manual review (${date})`;
-
-async function createIssue() {
-  const [owner, repo] = repoFullName.split('/');
-
-  // Ensure labels exist (best-effort – ignore 422 if already present)
-  for (const label of [
-    { name: 'dependencies', color: '0075ca', description: 'Pull requests that update a dependency file' },
-    { name: 'needs-review', color: 'e4e669', description: 'Requires human or agent review before merging' },
-  ]) {
-    await fetch(`https://api.github.com/repos/${owner}/${repo}/labels`, {
-      method: 'POST',
-      headers: authHeaders(),
-      body: JSON.stringify(label),
-    }).catch(() => {});
-  }
-
-  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
-    method: 'POST',
-    headers: authHeaders(),
-    body: JSON.stringify({
-      title,
-      body,
-      labels: ['dependencies', 'needs-review'],
-    }),
-  });
-
-  if (!res.ok) {
-    const err = await res.text();
-    console.error('Failed to create issue:', res.status, err);
-    process.exit(1);
-  }
-
-  const issue = await res.json();
-  console.log(`✅ Issue created: ${issue.html_url}`);
-}
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 function authHeaders() {
   return {
@@ -111,7 +42,125 @@ function authHeaders() {
   };
 }
 
-createIssue().catch((err) => {
+async function ensureLabels() {
+  const labels = [
+    { name: 'dependencies', color: '0075ca', description: 'Pull requests that update a dependency file' },
+    { name: 'copilot', color: '6f42c1', description: 'Assigned to GitHub Copilot coding agent' },
+  ];
+  for (const label of labels) {
+    await fetch(`https://api.github.com/repos/${owner}/${repo}/labels`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify(label),
+    }).catch(() => {});
+  }
+}
+
+async function findExistingIssue(packageName) {
+  const q = `repo:${owner}/${repo} is:issue is:open in:title "[npm Update Agent] Update ${packageName}"`;
+  const res = await fetch(
+    `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`,
+    { headers: authHeaders() },
+  );
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.items?.[0] || null;
+}
+
+// ── Build issue body for a single package ────────────────────────────────────
+
+function buildIssueBody(u) {
+  const badge = u.uncertain ? '⚠️ Uncertain (changelog unavailable)' : '🔴 Breaking changes detected';
+  const releaseLinks = u.githubUrl ? `[Release notes](${u.githubUrl})` : '';
+  const npmLink = u.npmUrl ? `[npm page](${u.npmUrl})` : '';
+  const refs = [releaseLinks, npmLink].filter(Boolean).join(' · ');
+
+  let body = '';
+  body += `## Context\n\n`;
+  body += `The **npm update agent** workflow detected that \`${u.package}\` needs a **${u.updateType}** version update.\n\n`;
+  body += `| Field | Value |\n|---|---|\n`;
+  body += `| Package | \`${u.package}\` |\n`;
+  body += `| Current version | \`${u.current}\` |\n`;
+  body += `| Latest version | \`${u.latest}\` |\n`;
+  body += `| Update type | ${u.updateType} |\n`;
+  body += `| Status | ${badge} |\n`;
+  body += `| Reason | ${u.reason} |\n`;
+  if (refs) body += `| References | ${refs} |\n`;
+
+  if (u.affectedReleases?.length) {
+    body += `\n### Relevant releases\n\n`;
+    for (const r of u.affectedReleases) {
+      body += `- \`${r.tag}\` — ${r.title || '(no title)'}\n`;
+    }
+  }
+
+  body += `\n---\n\n`;
+  body += `## Task for Copilot\n\n`;
+  body += `Please perform the following steps:\n\n`;
+  body += `1. **Update the package** — run:\n`;
+  body += `   \`\`\`bash\n   npm install ${u.package}@latest\n   \`\`\`\n`;
+  body += `2. **Build the site** — run:\n`;
+  body += `   \`\`\`bash\n   npx hexo generate\n   \`\`\`\n`;
+  body += `3. **If the build fails**, read the error messages and the release notes linked above, `;
+  body += `then fix any breaking changes in the source code. Common fixes include:\n`;
+  body += `   - Updating renamed/removed API calls or imports\n`;
+  body += `   - Adjusting configuration keys in \`_config.yml\` or \`_config.cactus.yml\`\n`;
+  body += `   - Replacing deprecated plugin options\n`;
+  body += `4. **Repeat steps 2–3** until \`npx hexo generate\` succeeds.\n`;
+  body += `5. Commit all changes (\`package.json\`, \`package-lock.json\`, and any source fixes).\n\n`;
+  body += `> ⚠️ Do NOT modify content files under \`source/_posts/\` unless a breaking change directly affects markdown rendering.\n\n`;
+  body += `---\n`;
+  body += `> 🤖 This issue was automatically created by the [npm update agent workflow](.github/workflows/npm-update-agent.yml) on ${date}.\n`;
+
+  return body;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  await ensureLabels();
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const u of breakingUpdates) {
+    const title = `⬆️ [npm Update Agent] Update \`${u.package}\` from ${u.current} to ${u.latest}`;
+
+    // Skip if an open issue already exists for this package
+    const existing = await findExistingIssue(u.package);
+    if (existing) {
+      console.log(`⏭️  Issue already exists for ${u.package}: ${existing.html_url}`);
+      skipped++;
+      continue;
+    }
+
+    const body = buildIssueBody(u);
+
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        title,
+        body,
+        labels: ['dependencies', 'copilot'],
+      }),
+    });
+
+    if (!res.ok) {
+      const err = await res.text();
+      console.error(`❌ Failed to create issue for ${u.package}:`, res.status, err);
+      continue;
+    }
+
+    const issue = await res.json();
+    console.log(`✅ Issue created for ${u.package}: ${issue.html_url}`);
+    created++;
+  }
+
+  console.log(`\n📋 Summary: ${created} issue(s) created, ${skipped} skipped (already open).`);
+}
+
+main().catch((err) => {
   console.error('Fatal error:', err);
   process.exit(1);
 });

--- a/.github/scripts/create-breaking-issue.js
+++ b/.github/scripts/create-breaking-issue.js
@@ -1,0 +1,117 @@
+/**
+ * create-breaking-issue.js
+ *
+ * Reads breaking-updates.json and opens a GitHub issue that lists every
+ * package with a detected (or uncertain) breaking change.
+ * The issue is labelled `dependencies` + `needs-review` so it can be
+ * picked up by a team member or a GitHub Copilot coding agent.
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+const breakingUpdates = JSON.parse(fs.readFileSync('breaking-updates.json', 'utf8'));
+
+if (breakingUpdates.length === 0) {
+  console.log('No breaking updates to report.');
+  process.exit(0);
+}
+
+const token = process.env.GITHUB_TOKEN;
+const repoFullName = process.env.GITHUB_REPOSITORY; // e.g. "owner/repo"
+
+if (!token || !repoFullName) {
+  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY must be set.');
+  process.exit(1);
+}
+
+const date = new Date().toISOString().split('T')[0];
+
+// ── Build issue body ─────────────────────────────────────────────────────────
+
+let body = `# ⚠️ npm Packages Requiring Manual Review\n\n`;
+body += `The **npm update agent** detected the following packages that either contain breaking changes or could not be verified automatically. Please review before updating.\n\n`;
+body += `**Detected on:** ${date}\n\n`;
+body += `---\n\n`;
+
+for (const u of breakingUpdates) {
+  const badge = u.uncertain ? '⚠️ Uncertain' : '🔴 Breaking changes detected';
+  body += `## \`${u.package}\` — \`${u.current}\` → \`${u.latest}\` (${u.updateType})\n\n`;
+  body += `| Field | Value |\n|---|---|\n`;
+  body += `| Status | ${badge} |\n`;
+  body += `| Reason | ${u.reason} |\n`;
+
+  if (u.githubUrl) body += `| Release notes | [View on GitHub](${u.githubUrl}) |\n`;
+  if (u.npmUrl) body += `| npm page | [View on npm](${u.npmUrl}) |\n`;
+
+  if (u.affectedReleases?.length) {
+    const tags = u.affectedReleases.map((r) => `\`${r.tag}\``).join(', ');
+    body += `| Versions to review | ${tags} |\n`;
+  }
+
+  body += `\n`;
+}
+
+body += `---\n\n`;
+body += `## ✅ Suggested Action Steps\n\n`;
+body += `1. Open the release-notes links above and check for removed APIs or config changes.\n`;
+body += `2. If the update is safe, run locally:\n`;
+body += `   \`\`\`bash\n   npm install <package>@latest\n   npm run build   # or: hexo generate\n   \`\`\`\n`;
+body += `3. Fix any broken code (imports, config keys, deprecated options).\n`;
+body += `4. Push a PR and let the CI build verify the result.\n\n`;
+body += `---\n`;
+body += `> 🤖 This issue was automatically created by the [npm update agent workflow](.github/workflows/npm-update-agent.yml).\n`;
+
+// ── Create the GitHub issue ──────────────────────────────────────────────────
+
+const title = `⚠️ [npm Update Agent] ${breakingUpdates.length} package(s) need manual review (${date})`;
+
+async function createIssue() {
+  const [owner, repo] = repoFullName.split('/');
+
+  // Ensure labels exist (best-effort – ignore 422 if already present)
+  for (const label of [
+    { name: 'dependencies', color: '0075ca', description: 'Pull requests that update a dependency file' },
+    { name: 'needs-review', color: 'e4e669', description: 'Requires human or agent review before merging' },
+  ]) {
+    await fetch(`https://api.github.com/repos/${owner}/${repo}/labels`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify(label),
+    }).catch(() => {});
+  }
+
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({
+      title,
+      body,
+      labels: ['dependencies', 'needs-review'],
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    console.error('Failed to create issue:', res.status, err);
+    process.exit(1);
+  }
+
+  const issue = await res.json();
+  console.log(`✅ Issue created: ${issue.html_url}`);
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+createIssue().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,22 @@
+name: "Copilot Setup Steps"
+
+on: repository_dispatch
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install hexo-cli
+        run: npm install -g hexo-cli

--- a/.github/workflows/npm-update-agent.yml
+++ b/.github/workflows/npm-update-agent.yml
@@ -97,10 +97,11 @@ jobs:
             automated
 
   # ─────────────────────────────────────────────
-  # Job 3: Create issue for packages with breaking changes
+  # Job 3: Create per-package issues for breaking changes
+  #         → labelled `copilot` so Copilot coding agent picks them up
   # ─────────────────────────────────────────────
   report-breaking-changes:
-    name: Report Breaking Changes
+    name: Create Copilot Issues for Breaking Changes
     needs: analyze
     if: needs.analyze.outputs.has_breaking_updates == 'true'
     runs-on: ubuntu-latest
@@ -118,7 +119,7 @@ jobs:
         with:
           name: update-analysis
 
-      - name: Create issue for packages needing manual review
+      - name: Create Copilot issues for packages with breaking changes
         run: node .github/scripts/create-breaking-issue.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-update-agent.yml
+++ b/.github/workflows/npm-update-agent.yml
@@ -1,0 +1,125 @@
+name: npm Packages Update Agent
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Job 1: Scan outdated packages & detect breaking changes
+  # ─────────────────────────────────────────────
+  analyze:
+    name: Analyze Package Updates
+    runs-on: ubuntu-latest
+    outputs:
+      has_safe_updates: ${{ steps.analyze.outputs.has_safe_updates }}
+      has_breaking_updates: ${{ steps.analyze.outputs.has_breaking_updates }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install current dependencies
+        run: npm ci
+
+      - name: Analyze outdated packages
+        id: analyze
+        run: node .github/scripts/analyze-updates.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload analysis results
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-analysis
+          path: |
+            safe-updates.json
+            breaking-updates.json
+          retention-days: 1
+
+  # ─────────────────────────────────────────────
+  # Job 2: Apply safe updates, verify build, open PR
+  # ─────────────────────────────────────────────
+  apply-safe-updates:
+    name: Apply Safe Updates & Create PR
+    needs: analyze
+    if: needs.analyze.outputs.has_safe_updates == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install current dependencies
+        run: npm ci
+
+      - name: Download analysis results
+        uses: actions/download-artifact@v4
+        with:
+          name: update-analysis
+
+      - name: Apply safe package updates
+        run: node .github/scripts/apply-updates.js
+
+      - name: Install hexo-cli for build verification
+        run: npm install -g hexo-cli
+
+      - name: Verify blog builds successfully
+        run: hexo generate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(deps): update npm packages to latest versions'
+          title: '⬆️ Auto-update npm packages'
+          body-path: pr-body.md
+          branch: 'auto-update/npm-packages'
+          delete-branch: true
+          labels: |
+            dependencies
+            automated
+
+  # ─────────────────────────────────────────────
+  # Job 3: Create issue for packages with breaking changes
+  # ─────────────────────────────────────────────
+  report-breaking-changes:
+    name: Report Breaking Changes
+    needs: analyze
+    if: needs.analyze.outputs.has_breaking_updates == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download analysis results
+        uses: actions/download-artifact@v4
+        with:
+          name: update-analysis
+
+      - name: Create issue for packages needing manual review
+        run: node .github/scripts/create-breaking-issue.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions **agentic workflow** that automatically:

1. **Scans** for outdated npm packages every Monday (or on demand)
2. **Analyses** whether major-version bumps contain breaking changes by inspecting GitHub release notes
3. **Auto-updates** safe packages and creates a PR (with build verification via `hexo generate`)
4. **Opens a GitHub Issue** for packages that need manual review, labelled `dependencies` + `needs-review`

---

## New files

| File | Purpose |
|---|---|
| `.github/workflows/npm-update-agent.yml` | Main workflow (3 parallel jobs) |
| `.github/scripts/analyze-updates.js` | Scans `npm outdated`, fetches release notes, detects breaking changes |
| `.github/scripts/apply-updates.js` | Patches `package.json`, runs `npm install`, writes PR body |
| `.github/scripts/create-breaking-issue.js` | Opens a GitHub Issue for packages needing review |

## Workflow diagram

```
schedule (Mon 08:00 UTC) / workflow_dispatch
        │
        ▼
┌─────────────────────────────────────────┐
│  Job 1 – analyze                        │
│  npm outdated → GitHub releases API     │
│  ↓ patch/minor → safe                   │
│  ↓ major + no keywords → safe           │
│  ↓ major + BREAKING keywords → review   │
│  ↓ major + no changelog → review        │
└──────────┬──────────────────────────────┘
           │
    ┌──────┴────────┐
    ▼               ▼
Job 2           Job 3
Apply safe      Open Issue
updates →       (labelled
hexo build →    needs-review)
Create PR
```

## Updated files

- `.github/dependabot.yml` – disabled routine version-bump PRs to avoid conflicts; security alerts remain active.